### PR TITLE
Fix launchdota.sh: Replace dream-sports-labs with ds-horizon

### DIFF
--- a/launchdota.sh
+++ b/launchdota.sh
@@ -78,7 +78,7 @@ if [ -d "dota" ]; then
     git checkout main
     git pull origin main
 else
-    git clone -b main git@github.com:dream-sports-labs/dota.git
+    git clone -b main git@github.com:ds-horizon/dota.git
     cd dota
 fi
 


### PR DESCRIPTION
This PR fixes the missed `launchdota.sh` file that still contained "dream-sports-labs" reference.

## Changes Made
- Updated launchdota.sh to replace "dream-sports-labs" with "ds-horizon" in the git clone URL

## Files Modified
- launchdota.sh

This ensures consistency with the organization name change across all files in the repository.